### PR TITLE
Add `Duration.inIntUnits`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Extension properties are supplied on `Int`, `Long`, and `Double` to make creatin
 2.days
 ```
 
-There are also extension properties supplied on `Duration` to get the underlying value as a `Double`:
+There are also extension properties supplied on `Duration` to get the underlying value as a `Double` abd as `Int`:
 
 ```kotlin
 val duration = 2.seconds
@@ -66,6 +66,14 @@ duration.inDoubleSeconds
 duration.inDoubleMinutes
 duration.inDoubleHours
 duration.inDoubleDays
+
+duration.inWholeIntNanoseconds
+duration.inWholeIntMicroseconds
+duration.inWholeIntMilliseconds
+duration.inWholeIntSeconds
+duration.inWholeIntMinutes
+duration.inWholeIntHours
+duration.inWholeIntDays
 ```
 
 ### Rationale
@@ -79,3 +87,5 @@ This library brings them back 🎉
 In addition, the `Duration` properties that returned the value as a `Double` have been deprecated.  This is because `Duration` is now backed by a `Long`.
 
 The new way to retrieve the value as a `Double` is to use `Duration.toDouble(DurationUnit)`. That can be a little verbose, so this library provides `Duration.inDouble*` functions.
+
+Since a lot of existing APIs accept and `Int` amount of milliseconds/seconds/etc, so this library also provides `Duration.inWholeInt*` functions.

--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ In addition, the `Duration` properties that returned the value as a `Double` hav
 
 The new way to retrieve the value as a `Double` is to use `Duration.toDouble(DurationUnit)`. That can be a little verbose, so this library provides `Duration.inDouble*` functions.
 
-Since a lot of existing APIs accept and `Int` amount of milliseconds/seconds/etc, so this library also provides `Duration.inWholeInt*` functions.
+Since a lot of existing APIs accept an `Int` amount of milliseconds/seconds/etc, this library also provides `Duration.inWholeInt*` functions.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Extension properties are supplied on `Int`, `Long`, and `Double` to make creatin
 2.days
 ```
 
-There are also extension properties supplied on `Duration` to get the underlying value as a `Double` abd as `Int`:
+There are also extension properties supplied on `Duration` to get the underlying value as a `Double` and as an `Int`:
 
 ```kotlin
 val duration = 2.seconds

--- a/library/src/commonMain/kotlin/com/eygraber/duration/extensions/Duration.kt
+++ b/library/src/commonMain/kotlin/com/eygraber/duration/extensions/Duration.kt
@@ -147,7 +147,7 @@ public inline val Duration.inDoubleHours: Double
   get() = toDouble(DurationUnit.HOURS)
 
 /**
- * Returns the value of this duration expressed as a [Int] number of hours.
+ * Returns the value of this duration expressed as an [Int] number of hours.
  *
  * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
  */
@@ -166,7 +166,7 @@ public inline val Duration.inDoubleMinutes: Double
   get() = toDouble(DurationUnit.MINUTES)
 
 /**
- * Returns the value of this duration expressed as a [Int] number of minutes.
+ * Returns the value of this duration expressed as an [Int] number of minutes.
  *
  * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
  */
@@ -185,7 +185,7 @@ public inline val Duration.inDoubleSeconds: Double
   get() = toDouble(DurationUnit.SECONDS)
 
 /**
- * Returns the value of this duration expressed as a [Int] number of seconds.
+ * Returns the value of this duration expressed as an [Int] number of seconds.
  *
  * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
  */
@@ -204,7 +204,7 @@ public inline val Duration.inDoubleMilliseconds: Double
   get() = toDouble(DurationUnit.MILLISECONDS)
 
 /**
- * Returns the value of this duration expressed as a [Int] number of milliseconds.
+ * Returns the value of this duration expressed as an [Int] number of milliseconds.
  *
  * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
  */
@@ -223,7 +223,7 @@ public inline val Duration.inDoubleMicroseconds: Double
   get() = toDouble(DurationUnit.MICROSECONDS)
 
 /**
- * Returns the value of this duration expressed as a [Int] number of microseconds.
+ * Returns the value of this duration expressed as an [Int] number of microseconds.
  *
  * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
  */
@@ -242,7 +242,7 @@ public inline val Duration.inDoubleNanoseconds: Double
   get() = toDouble(DurationUnit.NANOSECONDS)
 
 /**
- * Returns the value of this duration expressed as a [Int] number of nanoseconds.
+ * Returns the value of this duration expressed as an [Int] number of nanoseconds.
  *
  * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
  */

--- a/library/src/commonMain/kotlin/com/eygraber/duration/extensions/Duration.kt
+++ b/library/src/commonMain/kotlin/com/eygraber/duration/extensions/Duration.kt
@@ -127,7 +127,7 @@ public inline val Duration.inDoubleDays: Double
   get() = toDouble(DurationUnit.DAYS)
 
 /**
- * Returns the value of this duration expressed as a [Int] number of days.
+ * Returns the value of this duration expressed as an [Int] number of days.
  *
  * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
  */

--- a/library/src/commonMain/kotlin/com/eygraber/duration/extensions/Duration.kt
+++ b/library/src/commonMain/kotlin/com/eygraber/duration/extensions/Duration.kt
@@ -132,7 +132,7 @@ public inline val Duration.inDoubleDays: Double
  * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
  */
 @ExperimentalTime
-public inline val Duration.inIntDays: Int
+public inline val Duration.inWholeIntDays: Int
   get() = toInt(DurationUnit.DAYS)
 
 
@@ -152,7 +152,7 @@ public inline val Duration.inDoubleHours: Double
  * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
  */
 @ExperimentalTime
-public inline val Duration.inIntHours: Int
+public inline val Duration.inWholeIntHours: Int
   get() = toInt(DurationUnit.HOURS)
 
 /**
@@ -171,7 +171,7 @@ public inline val Duration.inDoubleMinutes: Double
  * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
  */
 @ExperimentalTime
-public inline val Duration.inIntMinutes: Int
+public inline val Duration.inWholeIntMinutes: Int
   get() = toInt(DurationUnit.MINUTES)
 
 /**
@@ -190,7 +190,7 @@ public inline val Duration.inDoubleSeconds: Double
  * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
  */
 @ExperimentalTime
-public inline val Duration.inIntSeconds: Int
+public inline val Duration.inWholeIntSeconds: Int
   get() = toInt(DurationUnit.SECONDS)
 
 /**
@@ -209,7 +209,7 @@ public inline val Duration.inDoubleMilliseconds: Double
  * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
  */
 @ExperimentalTime
-public inline val Duration.inIntMilliseconds: Int
+public inline val Duration.inWholeIntMilliseconds: Int
   get() = toInt(DurationUnit.MILLISECONDS)
 
 /**
@@ -228,7 +228,7 @@ public inline val Duration.inDoubleMicroseconds: Double
  * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
  */
 @ExperimentalTime
-public inline val Duration.inIntMicroseconds: Int
+public inline val Duration.inWholeIntMicroseconds: Int
   get() = toInt(DurationUnit.MICROSECONDS)
 
 /**
@@ -247,5 +247,5 @@ public inline val Duration.inDoubleNanoseconds: Double
  * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
  */
 @ExperimentalTime
-public inline val Duration.inIntNanoseconds: Int
+public inline val Duration.inWholeIntNanoseconds: Int
   get() = toInt(DurationUnit.NANOSECONDS)

--- a/library/src/commonMain/kotlin/com/eygraber/duration/extensions/Duration.kt
+++ b/library/src/commonMain/kotlin/com/eygraber/duration/extensions/Duration.kt
@@ -127,6 +127,16 @@ public inline val Duration.inDoubleDays: Double
   get() = toDouble(DurationUnit.DAYS)
 
 /**
+ * Returns the value of this duration expressed as a [Int] number of days.
+ *
+ * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
+ */
+@ExperimentalTime
+public inline val Duration.inIntDays: Int
+  get() = toInt(DurationUnit.DAYS)
+
+
+/**
  * Returns the value of this duration expressed as a [Double] number of hours.
  *
  * An infinite duration value is converted either to [Double.POSITIVE_INFINITY] or [Double.NEGATIVE_INFINITY]
@@ -135,6 +145,15 @@ public inline val Duration.inDoubleDays: Double
 @ExperimentalTime
 public inline val Duration.inDoubleHours: Double
   get() = toDouble(DurationUnit.HOURS)
+
+/**
+ * Returns the value of this duration expressed as a [Int] number of hours.
+ *
+ * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
+ */
+@ExperimentalTime
+public inline val Duration.inIntHours: Int
+  get() = toInt(DurationUnit.HOURS)
 
 /**
  * Returns the value of this duration expressed as a [Double] number of minutes.
@@ -147,6 +166,15 @@ public inline val Duration.inDoubleMinutes: Double
   get() = toDouble(DurationUnit.MINUTES)
 
 /**
+ * Returns the value of this duration expressed as a [Int] number of minutes.
+ *
+ * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
+ */
+@ExperimentalTime
+public inline val Duration.inIntMinutes: Int
+  get() = toInt(DurationUnit.MINUTES)
+
+/**
  * Returns the value of this duration expressed as a [Double] number of seconds.
  *
  * An infinite duration value is converted either to [Double.POSITIVE_INFINITY] or [Double.NEGATIVE_INFINITY]
@@ -155,6 +183,15 @@ public inline val Duration.inDoubleMinutes: Double
 @ExperimentalTime
 public inline val Duration.inDoubleSeconds: Double
   get() = toDouble(DurationUnit.SECONDS)
+
+/**
+ * Returns the value of this duration expressed as a [Int] number of seconds.
+ *
+ * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
+ */
+@ExperimentalTime
+public inline val Duration.inIntSeconds: Int
+  get() = toInt(DurationUnit.SECONDS)
 
 /**
  * Returns the value of this duration expressed as a [Double] number of milliseconds.
@@ -167,6 +204,15 @@ public inline val Duration.inDoubleMilliseconds: Double
   get() = toDouble(DurationUnit.MILLISECONDS)
 
 /**
+ * Returns the value of this duration expressed as a [Int] number of milliseconds.
+ *
+ * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
+ */
+@ExperimentalTime
+public inline val Duration.inIntMilliseconds: Int
+  get() = toInt(DurationUnit.MILLISECONDS)
+
+/**
  * Returns the value of this duration expressed as a [Double] number of microseconds.
  *
  * An infinite duration value is converted either to [Double.POSITIVE_INFINITY] or [Double.NEGATIVE_INFINITY]
@@ -177,6 +223,15 @@ public inline val Duration.inDoubleMicroseconds: Double
   get() = toDouble(DurationUnit.MICROSECONDS)
 
 /**
+ * Returns the value of this duration expressed as a [Int] number of microseconds.
+ *
+ * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
+ */
+@ExperimentalTime
+public inline val Duration.inIntMicroseconds: Int
+  get() = toInt(DurationUnit.MICROSECONDS)
+
+/**
  * Returns the value of this duration expressed as a [Double] number of nanoseconds.
  *
  * An infinite duration value is converted either to [Double.POSITIVE_INFINITY] or [Double.NEGATIVE_INFINITY]
@@ -185,3 +240,12 @@ public inline val Duration.inDoubleMicroseconds: Double
 @ExperimentalTime
 public inline val Duration.inDoubleNanoseconds: Double
   get() = toDouble(DurationUnit.NANOSECONDS)
+
+/**
+ * Returns the value of this duration expressed as a [Int] number of nanoseconds.
+ *
+ * An infinite duration value is converted either to [Int.MAX_VALUE] or [Int.MIN_VALUE] depending on its sign.
+ */
+@ExperimentalTime
+public inline val Duration.inIntNanoseconds: Int
+  get() = toInt(DurationUnit.NANOSECONDS)


### PR DESCRIPTION
Turns out that a lot of the places where I use timeouts the API expects an int number of seconds/millis/etc.

Using `toInt(DurationUnit.SECONDS)` is too verbose and `inWholeSeconds.toInt()` isn't better, so I've
been adding `Duration.inIntUnits` extensions on a few of my projects.

This library sounds like a perfect place for those.

The current recommended properly for Longs is `inWholeUnits`. I'm not particularly fond of the `Whole`, but maybe this should be `inIntWholeUnits` instead?
Let me know what you think

---

BTW, thanks for this library! Very handy!
