### PR TITLE
Specify macOS-11 runner for actions

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -11,7 +11,7 @@ jobs:
   publish_archives:
     strategy:
       matrix:
-        os: [macOS-latest, windows-latest]
+        os: [macOS-11, windows-latest]
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
  - Kotlin 1.6.0 needs a newer version of xcode which the current macOS-latest doesn't have